### PR TITLE
Add double tabbed layout

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -92,3 +92,9 @@ poi-control button .fa {
 .btn:hover {
   outline: none;
 }
+.poi-tabs-container {
+  display: flex;
+}
+.poi-tabs-container > div {
+  flex: 1;
+}

--- a/assets/css/layout.horizonal.css
+++ b/assets/css/layout.horizonal.css
@@ -8,6 +8,12 @@ kan-game {
 poi-app {
   flex: 2 0px;
 }
+.double-tabbed kan-game {
+  flex: 4 0px;
+}
+.double-tabbed poi-app {
+  flex: 3 0px;
+}
 hr {
   display: none;
 }

--- a/views/app.cjsx
+++ b/views/app.cjsx
@@ -3,119 +3,15 @@ path = require 'path-extra'
 glob = require 'glob'
 {showItemInFolder, openItem} = require 'shell'
 {ROOT, EXROOT, _, $, $$, React, ReactBootstrap} = window
-{Button, ButtonToolbar, TabbedArea, TabPane, Alert, OverlayMixin, Modal, DropdownButton, OverlayTrigger, Tooltip} = ReactBootstrap
+{Button, Alert, OverlayMixin, Modal, OverlayTrigger, Tooltip} = ReactBootstrap
 {config, proxy, remote, log, success, warn, error, toggleModal} = window
 
-# Get components
-components = glob.sync(path.join(ROOT, 'views', 'components', '*'))
-# Discover plugins and remove unused plugins
-plugins = glob.sync(path.join(ROOT, 'plugins', '*'))
-exPlugins = glob.sync(path.join(EXROOT, 'plugins', '*'))
-plugins = plugins.concat(exPlugins)
-plugins = plugins.filter (filePath) ->
-  # Every plugin will be required
-  try
-    plugin = require filePath
-    return config.get "plugin.#{plugin.name}.enable", true
-  catch e
-    return false
-
-components = components.map (filePath) ->
-  component = require filePath
-  component.priority = 10000 unless component.priority?
-  component
-components = components.filter (component) ->
-  component.show isnt false and component.name != 'SettingsView'
-components = _.sortBy(components, 'priority')
-
-plugins = plugins.map (filePath) ->
-  plugin = require filePath
-  plugin.priority = 10000 unless plugin.priority?
-  plugin
-plugins = plugins.filter (plugin) ->
-  plugin.show isnt false
-plugins = _.sortBy(plugins, 'priority')
-tabbedPlugins = plugins.filter (plugin) ->
-  !plugin.handleClick?
-
-settings = require path.join(ROOT, 'views', 'components', 'settings')
-
 # Main tabbed area
-lockedTab = false
-ControlledTabArea = React.createClass
-  getInitialState: ->
-    key: 0
-  handleSelect: (key) ->
-    @setState {key}
-  handleCtrlOrCmdTabKeyDown: ->
-    @setState
-      key: 0
-  handleCtrlOrCmdNumberKeyDown: (num) ->
-    if num <= components.length + tabbedPlugins.length
-      @setState
-        key: num - 1
-  handleShiftTabKeyDown: ->
-    @setState
-      key: if @state.key? then (@state.key - 1 + components.length + tabbedPlugins.length) % (components.length + tabbedPlugins.length) else components.length + tabbedPlugins.length - 1
-  handleTabKeyDown: ->
-    @setState
-      key: if @state.key? then (@state.key + 1) % (components.length + tabbedPlugins.length) else 1
-  componentDidMount: ->
-    window.addEventListener 'keydown', (e) =>
-      if e.keyCode is 9
-        e.preventDefault()
-        return if lockedTab and e.repeat
-        lockedTab = true
-        setTimeout ->
-          lockedTab = false
-        , 200
-        if e.ctrlKey or e.metaKey
-          @handleCtrlOrCmdTabKeyDown()
-        else if e.shiftKey
-          @handleShiftTabKeyDown()
-        else
-          @handleTabKeyDown()
-      else if e.ctrlKey or e.metaKey
-        if e.keyCode >= 49 and e.keyCode <= 57
-          @handleCtrlOrCmdNumberKeyDown(e.keyCode - 48)
-        else if e.keyCode is 48
-          @handleCtrlOrCmdNumberKeyDown 10
-  render: ->
-    ### FIXME
-    # Animation disabled
-    # Relate to https://github.com/react-bootstrap/react-bootstrap/issues/287
-    ###
-    <TabbedArea activeKey={@state.key} onSelect={@handleSelect} animation={false}>
-    {
-      [
-        components.map (component, index) ->
-          <TabPane key={index} eventKey={index} tab={component.displayName} id={component.name} className='poi-app-tabpane'>
-          {
-            React.createElement component.reactClass
-          }
-          </TabPane>
-        <DropdownButton key={components.length} eventKey={-1} tab='插件' navItem={true}>
-        {
-          counter = 0
-          plugins.map (plugin, index) ->
-            if plugin.handleClick
-              <div key={components.length + 1 + index} tab={plugin.displayName} id={plugin.name} onClick={plugin.handleClick} />
-            else
-              <TabPane key={components.length + 1 + index} eventKey={components.length - 1 + (counter += 1)} tab={plugin.displayName} id={plugin.name} className='poi-app-tabpane'>
-              {
-                React.createElement plugin.reactClass
-              }
-              </TabPane>
-        }
-        </DropdownButton>
-        <TabPane key={1000} eventKey={1000} tab={settings.displayName} id={settings.name} className='poi-app-tabpane'>
-        {
-          React.createElement settings.reactClass
-        }
-        </TabPane>
-      ]
-    }
-    </TabbedArea>
+ControlledTabArea =
+  if config.get('poi.tabarea.double', false)
+    require './double-tabareas'
+  else
+    require './single-tabarea'
 
 # Alert info
 PoiAlert = React.createClass

--- a/views/components/settings/parts/poi-config.cjsx
+++ b/views/components/settings/parts/poi-config.cjsx
@@ -18,11 +18,17 @@ PoiConfig = React.createClass
     gameWidth: config.get('poi.scale', window.gameScale) * window.innerWidth
     useFixedResolution: if config.get('poi.scale') then true else false
     enableConfirmQuit: config.get 'poi.confirm.quit', false
+    enableDoubleTabbed: config.get 'poi.tabarea.double', false
   handleSetConfirmQuit: ->
     enabled = @state.enableConfirmQuit
     config.set 'poi.confirm.quit', !enabled
     @setState
       enableConfirmQuit: !enabled
+  handleSetDoubleTabbed: ->
+    enabled = @state.enableDoubleTabbed
+    config.set 'poi.tabarea.double', !enabled
+    @setState
+      enableDoubleTabbed: !enabled
   handleSetLayout: (layout) ->
     return if @state.layout == layout
     config.set 'poi.layout', layout
@@ -135,6 +141,9 @@ PoiConfig = React.createClass
             <Button bsStyle={if @state.layout == 'vertical' then 'success' else 'danger'} onClick={@handleSetLayout.bind @, 'vertical'} style={width: '100%'}>
               {if @state.layout == 'vertical' then '√ ' else ''}使用纵版布局
             </Button>
+          </Col>
+          <Col xs={12}>
+            <Input type="checkbox" label="切分组件与插件面板" checked={@state.enableDoubleTabbed} onChange={@handleSetDoubleTabbed} />
           </Col>
         </Grid>
       </div>

--- a/views/double-tabareas.cjsx
+++ b/views/double-tabareas.cjsx
@@ -1,0 +1,124 @@
+path = require 'path-extra'
+glob = require 'glob'
+{_, $, React, ReactBootstrap} = window
+{TabbedArea, TabPane, DropdownButton} = ReactBootstrap
+
+$('poi-main').className += 'double-tabbed'
+# Get components
+components = glob.sync(path.join(ROOT, 'views', 'components', '*'))
+# Discover plugins and remove unused plugins
+plugins = glob.sync(path.join(ROOT, 'plugins', '*'))
+exPlugins = glob.sync(path.join(EXROOT, 'plugins', '*'))
+plugins = plugins.concat(exPlugins)
+plugins = plugins.filter (filePath) ->
+  # Every plugin will be required
+  try
+    plugin = require filePath
+    return config.get "plugin.#{plugin.name}.enable", true
+  catch e
+    return false
+
+components = components.map (filePath) ->
+  component = require filePath
+  component.priority = 10000 unless component.priority?
+  component
+components = components.filter (component) ->
+  component.show isnt false and component.name != 'SettingsView'
+components = _.sortBy(components, 'priority')
+
+plugins = plugins.map (filePath) ->
+  plugin = require filePath
+  plugin.priority = 10000 unless plugin.priority?
+  plugin
+plugins = plugins.filter (plugin) ->
+  plugin.show isnt false
+plugins = _.sortBy(plugins, 'priority')
+tabbedPlugins = plugins.filter (plugin) ->
+  !plugin.handleClick?
+settings = require path.join(ROOT, 'views', 'components', 'settings')
+
+lockedTab = false
+ControlledTabArea = React.createClass
+  getInitialState: ->
+    key: [0, 0]
+  handleSelectLeft: (key) ->
+    @setState
+      key: [key, @state.key[1]]
+  handleSelectRight: (key) ->
+    @setState
+      key: [@state.key[0], key]
+  handleCtrlOrCmdTabKeyDown: ->
+    @setState
+      key: [(@state.key[0] + 1) % components.length, @state.key[1]]
+  handleCtrlOrCmdNumberKeyDown: (num) ->
+    if num <= tabbedPlugins.length
+      @setState
+        key: [@state.key[0], num - 1]
+  handleShiftTabKeyDown: ->
+    @setState
+      key: [@state.key[0], if @state.key[1]? then (@state.key[1] - 1 + tabbedPlugins.length) % tabbedPlugins.length else tabbedPlugins.length - 1]
+  handleTabKeyDown: ->
+    @setState
+      key: [@state.key[0], if @state.key[1]? then (@state.key[1] + 1) % tabbedPlugins.length else 1]
+  componentDidMount: ->
+    window.addEventListener 'keydown', (e) =>
+      if e.keyCode is 9
+        e.preventDefault()
+        return if lockedTab and e.repeat
+        lockedTab = true
+        setTimeout ->
+          lockedTab = false
+        , 200
+        if e.ctrlKey or e.metaKey
+          @handleCtrlOrCmdTabKeyDown()
+        else if e.shiftKey
+          @handleShiftTabKeyDown()
+        else
+          @handleTabKeyDown()
+      else if e.ctrlKey or e.metaKey
+        if e.keyCode >= 49 and e.keyCode <= 57
+          @handleCtrlOrCmdNumberKeyDown(e.keyCode - 48)
+        else if e.keyCode is 48
+          @handleCtrlOrCmdNumberKeyDown 10
+  render: ->
+    ### FIXME
+    # Animation disabled
+    # Relate to https://github.com/react-bootstrap/react-bootstrap/issues/287
+    ###
+    <div className='poi-tabs-container'>
+      <TabbedArea activeKey={@state.key[0]} onSelect={@handleSelectLeft} animation={false}>
+      {
+        [
+          components.map (component, index) ->
+            <TabPane key={index} eventKey={index} tab={component.displayName} id={component.name} className='poi-app-tabpane'>
+            {
+              React.createElement component.reactClass
+            }
+            </TabPane>
+          <TabPane key={1000} eventKey={1000} tab={settings.displayName} id={settings.name} className='poi-app-tabpane'>
+          {
+            React.createElement settings.reactClass
+          }
+          </TabPane>
+        ]
+      }
+      </TabbedArea>
+      <TabbedArea activeKey={@state.key[1]} onSelect={@handleSelectRight} animation={false}>
+        <DropdownButton key={-1} eventKey={-1} tab='插件' navItem={true}>
+        {
+          counter = -1
+          plugins.map (plugin, index) ->
+            if plugin.handleClick
+              <div key={index} tab={plugin.displayName} id={plugin.name} onClick={plugin.handleClick} />
+            else
+              <TabPane key={index} eventKey={counter += 1} tab={plugin.displayName} id={plugin.name} className='poi-app-tabpane'>
+              {
+                React.createElement plugin.reactClass
+              }
+              </TabPane>
+        }
+        </DropdownButton>
+      </TabbedArea>
+    </div>
+
+module.exports = ControlledTabArea

--- a/views/env.coffee
+++ b/views/env.coffee
@@ -104,7 +104,7 @@ window.proxy = remote.require './lib/proxy'
 
 # User configs
 window.layout = config.get 'poi.layout', 'horizonal'
-window.gameScale = config.get 'poi.scale', 5.0 / 7.0
+window.gameScale = config.get 'poi.scale', if config.get('poi.tabarea.double', false) then 4.0 / 7.0 else 5.0 / 7.0
 # Custom theme
 window.theme = config.get 'poi.theme', '__default__'
 if theme == '__default__'

--- a/views/single-tabarea.cjsx
+++ b/views/single-tabarea.cjsx
@@ -1,0 +1,115 @@
+path = require 'path-extra'
+glob = require 'glob'
+{_, React, ReactBootstrap} = window
+{TabbedArea, TabPane, DropdownButton} = ReactBootstrap
+
+# Get components
+components = glob.sync(path.join(ROOT, 'views', 'components', '*'))
+# Discover plugins and remove unused plugins
+plugins = glob.sync(path.join(ROOT, 'plugins', '*'))
+exPlugins = glob.sync(path.join(EXROOT, 'plugins', '*'))
+plugins = plugins.concat(exPlugins)
+plugins = plugins.filter (filePath) ->
+  # Every plugin will be required
+  try
+    plugin = require filePath
+    return config.get "plugin.#{plugin.name}.enable", true
+  catch e
+    return false
+
+components = components.map (filePath) ->
+  component = require filePath
+  component.priority = 10000 unless component.priority?
+  component
+components = components.filter (component) ->
+  component.show isnt false and component.name != 'SettingsView'
+components = _.sortBy(components, 'priority')
+
+plugins = plugins.map (filePath) ->
+  plugin = require filePath
+  plugin.priority = 10000 unless plugin.priority?
+  plugin
+plugins = plugins.filter (plugin) ->
+  plugin.show isnt false
+plugins = _.sortBy(plugins, 'priority')
+tabbedPlugins = plugins.filter (plugin) ->
+  !plugin.handleClick?
+settings = require path.join(ROOT, 'views', 'components', 'settings')
+
+lockedTab = false
+ControlledTabArea = React.createClass
+  getInitialState: ->
+    key: 0
+  handleSelect: (key) ->
+    @setState {key}
+  handleCtrlOrCmdTabKeyDown: ->
+    @setState
+      key: 0
+  handleCtrlOrCmdNumberKeyDown: (num) ->
+    if num <= components.length + tabbedPlugins.length
+      @setState
+        key: num - 1
+  handleShiftTabKeyDown: ->
+    @setState
+      key: if @state.key? then (@state.key - 1 + components.length + tabbedPlugins.length) % (components.length + tabbedPlugins.length) else components.length + tabbedPlugins.length - 1
+  handleTabKeyDown: ->
+    @setState
+      key: if @state.key? then (@state.key + 1) % (components.length + tabbedPlugins.length) else 1
+  componentDidMount: ->
+    window.addEventListener 'keydown', (e) =>
+      if e.keyCode is 9
+        e.preventDefault()
+        return if lockedTab and e.repeat
+        lockedTab = true
+        setTimeout ->
+          lockedTab = false
+        , 200
+        if e.ctrlKey or e.metaKey
+          @handleCtrlOrCmdTabKeyDown()
+        else if e.shiftKey
+          @handleShiftTabKeyDown()
+        else
+          @handleTabKeyDown()
+      else if e.ctrlKey or e.metaKey
+        if e.keyCode >= 49 and e.keyCode <= 57
+          @handleCtrlOrCmdNumberKeyDown(e.keyCode - 48)
+        else if e.keyCode is 48
+          @handleCtrlOrCmdNumberKeyDown 10
+  render: ->
+    ### FIXME
+    # Animation disabled
+    # Relate to https://github.com/react-bootstrap/react-bootstrap/issues/287
+    ###
+    <TabbedArea activeKey={@state.key} onSelect={@handleSelect} animation={false}>
+    {
+      [
+        components.map (component, index) ->
+          <TabPane key={index} eventKey={index} tab={component.displayName} id={component.name} className='poi-app-tabpane'>
+          {
+            React.createElement component.reactClass
+          }
+          </TabPane>
+        <DropdownButton key={components.length} eventKey={-1} tab='插件' navItem={true}>
+        {
+          counter = 0
+          plugins.map (plugin, index) ->
+            if plugin.handleClick
+              <div key={components.length + 1 + index} tab={plugin.displayName} id={plugin.name} onClick={plugin.handleClick} />
+            else
+              <TabPane key={components.length + 1 + index} eventKey={components.length - 1 + (counter += 1)} tab={plugin.displayName} id={plugin.name} className='poi-app-tabpane'>
+              {
+                React.createElement plugin.reactClass
+              }
+              </TabPane>
+        }
+        </DropdownButton>
+        <TabPane key={1000} eventKey={1000} tab={settings.displayName} id={settings.name} className='poi-app-tabpane'>
+        {
+          React.createElement settings.reactClass
+        }
+        </TabPane>
+      ]
+    }
+    </TabbedArea>
+
+module.exports = ControlledTabArea


### PR DESCRIPTION
This pr adds a option to open tabbed layout. It means that you can see game, components, plugins views at the same time. Hot keys are changed to

+ Cmd/Ctrl + Tab: Next component
+ Tab: Next plugin
+ Shift + Tab: Last plugin