### PR TITLE
Add shortcut to hide and restore

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -22,6 +22,7 @@ config = require './lib/config'
 proxy = require './lib/proxy'
 proxy.setMaxListeners 30
 update = require './lib/update'
+shortcut = require './lib/shortcut'
 {log, warn, error} = require './lib/utils'
 
 global.mainWindow = mainWindow = null
@@ -58,9 +59,11 @@ else if process.platform == 'darwin'
     app.commandLine.appendSwitch 'ppapi-flash-version', '18.0.0.209'
 
 app.on 'window-all-closed', ->
+  shortcut.unregister()
   app.quit()
 
 app.on 'ready', ->
+  shortcut.register()
   screen = require 'screen'
   screenSize = screen.getPrimaryDisplay().workAreaSize
   global.mainWindow = mainWindow = new BrowserWindow

--- a/lib/shortcut.coffee
+++ b/lib/shortcut.coffee
@@ -1,0 +1,23 @@
+BrowserWindow = require 'browser-window'
+globalShortcut = require 'global-shortcut'
+config = require './config'
+# Window state before hide
+state = []
+hidden = false
+module.exports =
+  register: ->
+    globalShortcut.register config.get('poi.shortcut.bosskey', 'CmdOrCtrl+p+o+i'), ->
+      windows = BrowserWindow.getAllWindows()
+      if !hidden
+        # Hide all windows
+        for w in windows
+          state[w.id] = w.isVisible()
+          w.hide()
+        hidden = true
+      else
+        # Restore all windows
+        for w in windows
+          w.show() if state[w.id]
+        hidden = false
+  unregister: ->
+    globalShortcut.unregisterAll()


### PR DESCRIPTION
This pr adds a shortcut to hide/restore windows quickly.

Config interface:
path: poi.shortcut.bosskey
type: [Electron Accelerator](https://github.com/atom/electron/blob/master/docs/api/accelerator.md)
default: 'CmdOrCtrl+p+o+i'